### PR TITLE
Add Next.js 14 Pattern Intelligence frontend dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+PORT=3000
+NODE_ENV=development

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+coverage
+.env
+npm-debug.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY --from=builder /app/dist ./dist
+COPY .env.example ./.env.example
+EXPOSE 3000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:3000/health || exit 1
+CMD ["node", "dist/src/index.js"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,193 @@
-# Pattern-Intelligence-API-Platform
-Pattern Detector API
+# Pattern Intelligence API Platform
+
+A production-ready Node.js/Express API written in TypeScript for pattern analysis across text payloads.
+
+## Features
+
+- Express.js + TypeScript architecture
+- Main analysis endpoint: `POST /api/analyze`
+- Supports **plain text** and **regex** pattern matching
+- Returns occurrences, match positions, and up to 5 samples per pattern
+- Request validation with descriptive 400 errors
+- Rate limiting: 100 requests per 15 minutes per IP
+- CORS enabled for all origins
+- HTTP request logging via Morgan
+- Health endpoint: `GET /health`
+- Unit + integration tests with Jest + Supertest
+- Docker multi-stage production image and docker-compose setup
+
+## Project Structure
+
+```text
+.
+├── src
+│   ├── index.ts
+│   ├── middleware
+│   │   └── validator.ts
+│   ├── routes
+│   │   └── analyze.ts
+│   ├── services
+│   │   └── patternDetector.ts
+│   └── types
+│       └── index.ts
+├── tests
+│   └── analyze.test.ts
+├── Dockerfile
+├── docker-compose.yml
+├── .env.example
+├── jest.config.ts
+├── package.json
+├── tsconfig.json
+└── README.md
+```
+
+## Requirements
+
+- Node.js 18+
+- npm 9+
+- (Optional) Docker + Docker Compose
+
+## Environment Variables
+
+Copy and customize:
+
+```bash
+cp .env.example .env
+```
+
+Variables:
+
+- `PORT` (default: `3000`)
+- `NODE_ENV` (`development`, `test`, `production`)
+
+## Local Setup
+
+```bash
+npm install
+npm run dev
+```
+
+The API runs on `http://localhost:3000`.
+
+## Scripts
+
+- `npm run dev` - start in development with nodemon + ts-node
+- `npm run build` - compile TypeScript into `dist/`
+- `npm run start` - run compiled production build
+- `npm test` - run tests with coverage thresholds
+
+## API
+
+### Health Check
+
+`GET /health`
+
+Response:
+
+```json
+{
+  "status": "ok",
+  "environment": "development"
+}
+```
+
+### Analyze Text
+
+`POST /api/analyze`
+
+Request body format:
+
+```json
+{
+  "text": "string",
+  "patterns": ["string"]
+}
+```
+
+Response body format:
+
+```json
+{
+  "matches": [
+    {
+      "pattern": "string",
+      "occurrences": 0,
+      "positions": [0],
+      "samples": ["string"]
+    }
+  ],
+  "metadata": {
+    "totalPatterns": 1,
+    "processingTime": "0.14ms"
+  }
+}
+```
+
+## Example cURL Calls (3 Use Cases)
+
+1. **Plain text matching**
+
+```bash
+curl -X POST http://localhost:3000/api/analyze \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "text": "error info error warning error",
+    "patterns": ["error"]
+  }'
+```
+
+2. **Regex matching** (email detection)
+
+```bash
+curl -X POST http://localhost:3000/api/analyze \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "text": "Users: a@b.com, c@d.org",
+    "patterns": ["/[a-z]+@[a-z]+\\.[a-z]+/g"]
+  }'
+```
+
+3. **Mixed patterns**
+
+```bash
+curl -X POST http://localhost:3000/api/analyze \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "text": "alpha beta alpha 123 beta",
+    "patterns": ["alpha", "/\\d+/g", "beta"]
+  }'
+```
+
+## Validation Rules
+
+- `text` must be a non-empty string
+- `text` max length: 50,000 chars
+- `patterns` must be an array
+- `patterns` size: 1 to 10
+- every pattern must be a non-empty string
+
+Invalid input returns HTTP `400` with a descriptive error message.
+
+## Testing
+
+```bash
+npm test
+```
+
+Coverage thresholds are enforced globally at **80%** for branches, functions, lines, and statements.
+
+## Docker
+
+Build and run:
+
+```bash
+docker-compose up --build
+```
+
+Service exposed at `http://localhost:3000`.
+
+Health check:
+
+```bash
+curl http://localhost:3000/health
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.9'
+services:
+  pattern-intelligence-api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - '3000:3000'
+    environment:
+      - PORT=3000
+      - NODE_ENV=production
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:3000/health']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_PATTERN_API_URL=http://localhost:3000/api/analyze

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,27 @@
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+ENV NEXT_TELEMETRY_DISABLED=1
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3001
+
+RUN addgroup -g 1001 -S nodejs && adduser -S nextjs -u 1001
+
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+EXPOSE 3001
+CMD ["node", "server.js"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,25 @@
+# Pattern Intelligence Frontend (Next.js 14)
+
+## Run locally
+
+```bash
+cp .env.example .env.local
+npm install
+npm run dev
+```
+
+Open http://localhost:3001
+
+## Build for production
+
+```bash
+npm run build
+npm run start
+```
+
+## Docker
+
+```bash
+docker build -t pattern-intelligence-frontend .
+docker run --rm -p 3001:3001 --env-file .env.example pattern-intelligence-frontend
+```

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'standalone'
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "pattern-intelligence-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev -p 3001",
+    "build": "next build",
+    "start": "next start -p 3001",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.11",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "autoprefixer": "10.4.19",
+    "postcss": "8.4.39",
+    "tailwindcss": "3.4.7",
+    "typescript": "5.5.3"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,0 +1,16 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  @apply bg-slate-900 text-slate-100 antialiased;
+}
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #334155 #0f172a;
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Pattern Intelligence Dashboard',
+  description: 'Modern Pattern Intelligence frontend for your Express API'
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { analyzeText, AnalyzeResponse } from '../lib/api';
+import { Alert } from '../components/ui/alert';
+import { Button } from '../components/ui/button';
+import { PatternInputList } from '../components/ui/pattern-input-list';
+import { TextArea } from '../components/ui/text-area';
+
+const MAX_TEXT = 50000;
+const MAX_PATTERNS = 10;
+
+export default function DashboardPage() {
+  const [text, setText] = useState('');
+  const [patterns, setPatterns] = useState<string[]>(['']);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string>('');
+  const [result, setResult] = useState<AnalyzeResponse | null>(null);
+
+  const totalMatches = useMemo(
+    () => result?.matches.reduce((acc, item) => acc + item.occurrences, 0) ?? 0,
+    [result]
+  );
+
+  const handleAnalyze = async () => {
+    setError('');
+
+    const filteredPatterns = patterns.map((p) => p.trim()).filter(Boolean);
+
+    if (!text.trim()) {
+      setError('Please enter text before running analysis.');
+      return;
+    }
+
+    if (text.length > MAX_TEXT) {
+      setError(`Text exceeds ${MAX_TEXT.toLocaleString()} character limit.`);
+      return;
+    }
+
+    if (filteredPatterns.length < 1 || filteredPatterns.length > MAX_PATTERNS) {
+      setError(`Please provide between 1 and ${MAX_PATTERNS} valid patterns.`);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      const data = await analyzeText({ text, patterns: filteredPatterns });
+      setResult(data);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unexpected error occurred during analysis.';
+      setError(message);
+      window.alert(`Pattern Intelligence API error: ${message}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="min-h-screen bg-slate-900 px-6 py-8 text-slate-100 lg:px-10">
+      <div className="mx-auto max-w-7xl">
+        <header className="mb-8 flex items-end justify-between border-b border-slate-800 pb-6">
+          <div>
+            <p className="text-xs uppercase tracking-[0.25em] text-cyan-400">Pattern Intelligence</p>
+            <h1 className="mt-2 text-3xl font-bold">Analysis Dashboard</h1>
+          </div>
+          <span className="rounded-full border border-cyan-500/40 bg-cyan-500/10 px-3 py-1 text-xs text-cyan-300">
+            Connected to localhost:3000
+          </span>
+        </header>
+
+        {error ? (
+          <div className="mb-4">
+            <Alert message={error} onClose={() => setError('')} />
+          </div>
+        ) : null}
+
+        <section className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+          <div className="rounded-2xl border border-slate-800 bg-slate-950/50 p-6 shadow-glow">
+            <h2 className="mb-5 text-lg font-semibold text-cyan-300">Analysis Configuration</h2>
+            <div className="space-y-5">
+              <TextArea value={text} onChange={setText} maxLength={MAX_TEXT} />
+              <PatternInputList patterns={patterns} onChange={setPatterns} maxItems={MAX_PATTERNS} />
+              <Button loading={loading} onClick={handleAnalyze} className="w-full">
+                Analyze Patterns
+              </Button>
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-slate-800 bg-slate-950/50 p-6 shadow-glow">
+            <h2 className="mb-5 text-lg font-semibold text-cyan-300">Intelligence Results</h2>
+
+            <div className="mb-5 grid grid-cols-2 gap-3">
+              <div className="rounded-xl border border-slate-800 bg-slate-900/70 p-4">
+                <p className="text-xs text-slate-400">Total Matches</p>
+                <p className="mt-2 text-2xl font-semibold text-cyan-400">{totalMatches}</p>
+              </div>
+              <div className="rounded-xl border border-slate-800 bg-slate-900/70 p-4">
+                <p className="text-xs text-slate-400">Processing Time</p>
+                <p className="mt-2 text-2xl font-semibold text-cyan-400">{result?.metadata.processingTime ?? '--'}</p>
+              </div>
+            </div>
+
+            <div className="max-h-[560px] space-y-3 overflow-y-auto pr-1">
+              {result?.matches.length ? (
+                result.matches.map((item, idx) => (
+                  <article key={`${item.pattern}-${idx}`} className="rounded-xl border border-slate-800 bg-slate-900/70 p-4">
+                    <div className="mb-2 flex items-center justify-between">
+                      <h3 className="font-medium text-cyan-300">{item.pattern}</h3>
+                      <span className="rounded-md bg-cyan-500/20 px-2 py-1 text-xs text-cyan-300">
+                        {item.occurrences} occurrences
+                      </span>
+                    </div>
+                    <div className="space-y-2">
+                      {item.samples.slice(0, 3).map((sample, sampleIndex) => (
+                        <p key={`${sample}-${sampleIndex}`} className="rounded-md border border-slate-800 bg-slate-950/70 p-2 text-sm text-slate-300">
+                          {sample}
+                        </p>
+                      ))}
+                      {!item.samples.length ? <p className="text-sm text-slate-500">No sample snippets found.</p> : null}
+                    </div>
+                  </article>
+                ))
+              ) : (
+                <div className="rounded-xl border border-dashed border-slate-700 p-8 text-center text-sm text-slate-400">
+                  No analysis yet. Submit text and patterns to view intelligence results.
+                </div>
+              )}
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/components/ui/alert.tsx
+++ b/frontend/src/components/ui/alert.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+type AlertProps = {
+  message: string;
+  onClose: () => void;
+};
+
+export function Alert({ message, onClose }: AlertProps) {
+  return (
+    <div className="rounded-lg border border-rose-600/50 bg-rose-950/40 p-3 text-sm text-rose-200 shadow-lg">
+      <div className="flex items-start justify-between gap-4">
+        <p>{message}</p>
+        <button onClick={onClose} className="text-rose-200/80 hover:text-white">
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  loading?: boolean;
+};
+
+export function Button({ loading = false, children, className = '', disabled, ...props }: ButtonProps) {
+  return (
+    <button
+      className={`inline-flex items-center justify-center rounded-lg bg-cyan-500 px-5 py-3 font-semibold text-slate-950 transition hover:bg-cyan-400 disabled:cursor-not-allowed disabled:opacity-60 ${className}`}
+      disabled={loading || disabled}
+      {...props}
+    >
+      {loading ? 'Analyzing...' : children}
+    </button>
+  );
+}

--- a/frontend/src/components/ui/pattern-input-list.tsx
+++ b/frontend/src/components/ui/pattern-input-list.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+type PatternInputListProps = {
+  patterns: string[];
+  onChange: (patterns: string[]) => void;
+  maxItems?: number;
+};
+
+export function PatternInputList({ patterns, onChange, maxItems = 10 }: PatternInputListProps) {
+  const update = (index: number, value: string) => {
+    const next = [...patterns];
+    next[index] = value;
+    onChange(next);
+  };
+
+  const addPattern = () => {
+    if (patterns.length < maxItems) {
+      onChange([...patterns, '']);
+    }
+  };
+
+  const removePattern = (index: number) => {
+    onChange(patterns.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <label className="text-sm font-medium text-slate-300">Patterns</label>
+        <span className="text-xs text-slate-400">{patterns.length}/{maxItems}</span>
+      </div>
+
+      {patterns.map((pattern, index) => (
+        <div key={index} className="flex items-center gap-2">
+          <input
+            value={pattern}
+            onChange={(event) => update(index, event.target.value)}
+            placeholder={index === 0 ? 'error' : '/\\d+/g'}
+            className="w-full rounded-lg border border-slate-700 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 outline-none ring-cyan-500/50 placeholder:text-slate-500 focus:ring"
+          />
+          <button
+            type="button"
+            onClick={() => removePattern(index)}
+            className="rounded-md border border-slate-700 px-3 py-2 text-xs text-slate-300 hover:border-cyan-500 hover:text-cyan-400"
+          >
+            Remove
+          </button>
+        </div>
+      ))}
+
+      <button
+        type="button"
+        onClick={addPattern}
+        disabled={patterns.length >= maxItems}
+        className="w-full rounded-lg border border-dashed border-slate-600 px-4 py-2 text-sm text-slate-300 hover:border-cyan-500 hover:text-cyan-400 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        + Add Pattern
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/text-area.tsx
+++ b/frontend/src/components/ui/text-area.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+type TextAreaProps = {
+  value: string;
+  onChange: (value: string) => void;
+  maxLength?: number;
+};
+
+export function TextArea({ value, onChange, maxLength = 50000 }: TextAreaProps) {
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-medium text-slate-300">Input Text</label>
+      <textarea
+        value={value}
+        onChange={(event) => onChange(event.target.value.slice(0, maxLength))}
+        placeholder="Paste logs, emails, documents, or raw text to analyze..."
+        className="h-64 w-full rounded-xl border border-slate-700 bg-slate-950/60 p-4 text-sm text-slate-100 outline-none ring-cyan-500/50 placeholder:text-slate-500 focus:ring"
+      />
+      <p className="text-right text-xs text-slate-400">{value.length.toLocaleString()} / {maxLength.toLocaleString()}</p>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,41 @@
+export interface AnalyzeRequest {
+  text: string;
+  patterns: string[];
+}
+
+export interface PatternMatch {
+  pattern: string;
+  occurrences: number;
+  positions: number[];
+  samples: string[];
+}
+
+export interface AnalyzeResponse {
+  matches: PatternMatch[];
+  metadata: {
+    totalPatterns: number;
+    processingTime: string;
+  };
+}
+
+const API_URL = process.env.NEXT_PUBLIC_PATTERN_API_URL ?? 'http://localhost:3000/api/analyze';
+
+export async function analyzeText(payload: AnalyzeRequest): Promise<AnalyzeResponse> {
+  const response = await fetch(API_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(payload),
+    cache: 'no-store'
+  });
+
+  const body = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    const message = typeof body?.error === 'string' ? body.error : `Request failed with status ${response.status}`;
+    throw new Error(message);
+  }
+
+  return body as AnalyzeResponse;
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,23 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          bg: '#0f172a',
+          panel: '#111827',
+          border: '#1f2937',
+          accent: '#06b6d4'
+        }
+      },
+      boxShadow: {
+        glow: '0 0 0 1px rgba(6,182,212,0.2), 0 10px 30px rgba(6,182,212,0.1)'
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,19 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
+  collectCoverageFrom: ['src/**/*.ts'],
+  coveragePathIgnorePatterns: ['/node_modules/'],
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80
+    }
+  }
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "pattern-intelligence-api-platform",
+  "version": "1.0.0",
+  "description": "Production-ready Pattern Intelligence API built with Express and TypeScript",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "nodemon --watch src --ext ts --exec ts-node src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "jest --coverage"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "express-rate-limit": "^7.4.0",
+    "morgan": "^1.10.0"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.12",
+    "@types/morgan": "^1.9.9",
+    "@types/node": "^20.14.11",
+    "@types/supertest": "^6.0.2",
+    "jest": "^29.7.0",
+    "nodemon": "^3.1.4",
+    "supertest": "^7.0.0",
+    "ts-jest": "^29.2.3",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.3"
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,46 @@
+import cors from 'cors';
+import dotenv from 'dotenv';
+import express, { Request, Response, NextFunction } from 'express';
+import rateLimit from 'express-rate-limit';
+import morgan from 'morgan';
+import analyzeRouter from './routes/analyze';
+
+dotenv.config();
+
+const app = express();
+const port = Number(process.env.PORT) || 3000;
+
+app.use(cors());
+app.use(morgan(process.env.NODE_ENV === 'production' ? 'combined' : 'dev'));
+app.use(express.json({ limit: '60kb' }));
+
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many requests, please try again later.' }
+});
+
+app.use(limiter);
+app.use('/api', analyzeRouter);
+
+app.get('/health', (_req: Request, res: Response) => {
+  res.status(200).json({ status: 'ok', environment: process.env.NODE_ENV || 'development' });
+});
+
+app.use((_req: Request, res: Response) => {
+  res.status(404).json({ error: 'Route not found.' });
+});
+
+app.use((error: Error, _req: Request, res: Response, _next: NextFunction) => {
+  res.status(500).json({ error: 'Internal server error.', details: error.message });
+});
+
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(port, () => {
+    console.log(`Pattern Intelligence API listening on port ${port}`);
+  });
+}
+
+export default app;

--- a/src/middleware/validator.ts
+++ b/src/middleware/validator.ts
@@ -1,0 +1,42 @@
+import { NextFunction, Request, Response } from 'express';
+
+const MAX_TEXT_LENGTH = 50000;
+const MIN_PATTERNS = 1;
+const MAX_PATTERNS = 10;
+
+export const validateAnalyzeRequest = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
+  const { text, patterns } = req.body as { text?: unknown; patterns?: unknown };
+
+  if (typeof text !== 'string' || text.trim().length === 0) {
+    res.status(400).json({ error: 'Invalid input: text must be a non-empty string.' });
+    return;
+  }
+
+  if (text.length > MAX_TEXT_LENGTH) {
+    res.status(400).json({ error: `Invalid input: text must be at most ${MAX_TEXT_LENGTH} characters.` });
+    return;
+  }
+
+  if (!Array.isArray(patterns)) {
+    res.status(400).json({ error: 'Invalid input: patterns must be an array of strings.' });
+    return;
+  }
+
+  if (patterns.length < MIN_PATTERNS || patterns.length > MAX_PATTERNS) {
+    res
+      .status(400)
+      .json({ error: `Invalid input: patterns must contain between ${MIN_PATTERNS} and ${MAX_PATTERNS} items.` });
+    return;
+  }
+
+  if (patterns.some((pattern) => typeof pattern !== 'string' || pattern.trim().length === 0)) {
+    res.status(400).json({ error: 'Invalid input: each pattern must be a non-empty string.' });
+    return;
+  }
+
+  next();
+};

--- a/src/routes/analyze.ts
+++ b/src/routes/analyze.ts
@@ -1,0 +1,23 @@
+import { Router, Request, Response } from 'express';
+import { validateAnalyzeRequest } from '../middleware/validator';
+import { analyzePatterns } from '../services/patternDetector';
+import { AnalyzeRequestBody } from '../types';
+
+const router = Router();
+
+router.post('/analyze', validateAnalyzeRequest, (req: Request<unknown, unknown, AnalyzeRequestBody>, res: Response) => {
+  try {
+    const { text, patterns } = req.body;
+    const result = analyzePatterns(text, patterns);
+    res.status(200).json(result);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      res.status(400).json({ error: `Invalid regex pattern: ${error.message}` });
+      return;
+    }
+
+    res.status(500).json({ error: 'Internal server error.' });
+  }
+});
+
+export default router;

--- a/src/services/patternDetector.ts
+++ b/src/services/patternDetector.ts
@@ -1,0 +1,63 @@
+import { PatternMatchResult } from '../types';
+
+const MAX_SAMPLES = 5;
+
+const REGEX_PATTERN_FORMAT = /^\/(.*)\/([dgimsuvy]*)$/;
+
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const toGlobalRegex = (pattern: string): RegExp => {
+  const regexParts = pattern.match(REGEX_PATTERN_FORMAT);
+
+  if (!regexParts) {
+    return new RegExp(escapeRegExp(pattern), 'g');
+  }
+
+  const [, source, rawFlags] = regexParts;
+  const dedupedFlags = Array.from(new Set(rawFlags.replace(/g/g, '').split(''))).join('');
+
+  return new RegExp(source, `${dedupedFlags}g`);
+};
+
+export const detectPattern = (text: string, pattern: string): PatternMatchResult => {
+  const matcher = toGlobalRegex(pattern);
+  const positions: number[] = [];
+  const samples: string[] = [];
+
+  let match = matcher.exec(text);
+
+  while (match) {
+    positions.push(match.index);
+    if (samples.length < MAX_SAMPLES) {
+      samples.push(match[0]);
+    }
+
+    if (match[0].length === 0) {
+      matcher.lastIndex += 1;
+    }
+
+    match = matcher.exec(text);
+  }
+
+  return {
+    pattern,
+    occurrences: positions.length,
+    positions,
+    samples
+  };
+};
+
+export const analyzePatterns = (text: string, patterns: string[]) => {
+  const start = process.hrtime.bigint();
+  const matches = patterns.map((pattern) => detectPattern(text, pattern));
+  const end = process.hrtime.bigint();
+
+  return {
+    matches,
+    metadata: {
+      totalPatterns: patterns.length,
+      processingTime: `${Number(end - start) / 1_000_000}ms`
+    }
+  };
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,19 @@
+export interface AnalyzeRequestBody {
+  text: string;
+  patterns: string[];
+}
+
+export interface PatternMatchResult {
+  pattern: string;
+  occurrences: number;
+  positions: number[];
+  samples: string[];
+}
+
+export interface AnalyzeResponse {
+  matches: PatternMatchResult[];
+  metadata: {
+    totalPatterns: number;
+    processingTime: string;
+  };
+}

--- a/tests/analyze.test.ts
+++ b/tests/analyze.test.ts
@@ -1,0 +1,79 @@
+import request from 'supertest';
+import app from '../src/index';
+import { analyzePatterns, detectPattern } from '../src/services/patternDetector';
+
+describe('Pattern detection logic', () => {
+  const mockCases = [
+    {
+      name: 'plain text matching',
+      text: 'alpha beta alpha gamma alpha',
+      pattern: 'alpha',
+      expectedOccurrences: 3,
+      expectedPositions: [0, 11, 23]
+    },
+    {
+      name: 'regex matching with flags',
+      text: 'Email: A@B.COM and c@d.com',
+      pattern: '/[a-z]+@[a-z]+\\.[a-z]+/i',
+      expectedOccurrences: 2,
+      expectedPositions: [7, 19]
+    },
+    {
+      name: 'sample limiting',
+      text: 'a a a a a a a',
+      pattern: 'a',
+      expectedOccurrences: 7,
+      expectedSampleCount: 5
+    }
+  ];
+
+  it.each(mockCases)('detectPattern - $name', ({ text, pattern, expectedOccurrences, expectedPositions, expectedSampleCount }) => {
+    const result = detectPattern(text, pattern);
+    expect(result.occurrences).toBe(expectedOccurrences);
+
+    if (expectedPositions) {
+      expect(result.positions).toEqual(expectedPositions);
+    }
+
+    if (expectedSampleCount) {
+      expect(result.samples).toHaveLength(expectedSampleCount);
+    }
+  });
+
+  it('analyzePatterns returns metadata and all results', () => {
+    const output = analyzePatterns('abc abc', ['abc', '/b./']);
+    expect(output.matches).toHaveLength(2);
+    expect(output.metadata.totalPatterns).toBe(2);
+    expect(output.metadata.processingTime).toMatch(/ms$/);
+  });
+});
+
+describe('API integration tests', () => {
+  it('POST /api/analyze should return matches and metadata', async () => {
+    const response = await request(app).post('/api/analyze').send({
+      text: 'cat dog cat bird',
+      patterns: ['cat', '/d.g/']
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('matches');
+    expect(response.body).toHaveProperty('metadata');
+    expect(response.body.metadata.totalPatterns).toBe(2);
+  });
+
+  it('POST /api/analyze should validate invalid payload', async () => {
+    const response = await request(app).post('/api/analyze').send({
+      text: '',
+      patterns: []
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toMatch(/Invalid input/);
+  });
+
+  it('GET /health should return healthy status', async () => {
+    const response = await request(app).get('/health');
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe('ok');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
### Motivation
- Provide a polished Next.js 14 + TypeScript + Tailwind dark B2B dashboard to interact with the Pattern Intelligence API and visualize results.
- Enable a production-ready deployment flow with a multi-stage Docker image and Next standalone output for containerized hosting.
- Offer a small, type-safe client integration and reusable UI components to make analysis easy and consistent.

### Description
- Added a new `frontend/` app with Next.js 14 App Router, TypeScript and Tailwind including `src/app/page.tsx`, layout, and global styles implementing a two-column dashboard (left: configuration; right: results).
- Implemented reusable UI components in `frontend/src/components/ui` for `TextArea`, `PatternInputList`, `Button`, and `Alert` with loading and validation UX.
- Added a type-safe API client `frontend/src/lib/api.ts` that posts to `NEXT_PUBLIC_PATTERN_API_URL` (default `http://localhost:3000/api/analyze`) and surfaces API errors.
- Added production deployment artifacts `frontend/Dockerfile`, `frontend/next.config.js` (`output: 'standalone'`), Tailwind and PostCSS configs, `.env.example`, and `frontend/README.md` for immediate usage.

### Testing
- Attempted `cd frontend && npm install`, but package installation failed due to external registry access (`403 Forbidden`), preventing a local build or `next build`.
- Attempted to validate the running frontend with a Playwright navigation to `http://127.0.0.1:3001`, which failed with `ERR_EMPTY_RESPONSE` because the server could not be started without successful install.
- Backend unit and integration tests were added under `tests/` for pattern detection and the API, but they were not executed in this environment due to the dependency/registry restriction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985285390b883279501af11f9bfab92)